### PR TITLE
feat: `strip()` to remove color tags from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ html("{red}\"<b>Bold Red</b>\"{/} &amp; '<i>{yellow}Italic Yellow{/}</i>'", fals
 // => <span class="wmred">"<b>Bold Red</b>"</span> &amp; '<i><span class="wmyellow">Italic Yellow</span></i>'
 ```
 
+## Removing Color Tags
+
+This library offers a `strip` method to remove color tags from a string:
+
+```js
+import { strip } from '@webmuds/colors'
+
+strip("{yellow}Yellow{/} Text")
+// => "Yellow Text"
+```
+
 ## CSS File
 
 This library provides the above CSS classes in `css/colors.css` so that you can import it in other projects. Classes are prefixed with `wm` to avoid collision.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
-import { html } from './src/html.js'
+// ts-check
 
-export { html }
+import { html } from './src/html.js'
+import { strip } from './src/strip.js'
+
+export { html, strip }

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,3 +19,8 @@ export const HTML_REPLACEMENT_TEMPLATE = '<span class="wm$2">$3</span>'
   * The main Regular Expression for performing replacements.
   */
 export const COLOR_RX = new RegExp('({((?:' + COLORS + '))}((?:(?!{(' + COLORS + '|/)}).)*)({/})*)', 'gims')
+
+/**
+ * RegExp to strip all color tags.
+ */
+export const STRIP_RX = new RegExp('{(?:' + COLORS + '|/)}', 'gim')

--- a/src/strip.js
+++ b/src/strip.js
@@ -1,0 +1,15 @@
+// @ts-check
+
+'use strict'
+
+import { STRIP_RX } from './constants.js'
+
+/**
+ * Strips all color tags from a string.
+ *
+ * @param {string} string
+ * @returns {string}
+ */
+export function strip (string) {
+  return string.replace(STRIP_RX, '')
+}

--- a/test/html.js
+++ b/test/html.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-import { expect } from 'chai'
+import { expect } from '@dimensionalpocket/development'
 import { html } from '../src/html.js'
 
 describe('#html', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -2,12 +2,17 @@
 
 'use strict'
 
-import { expect } from 'chai'
-import { html } from '../index.js'
+import { expect } from '@dimensionalpocket/development'
+import { html, strip } from '../index.js'
 import { html as htmlFromSrc } from '../src/html.js'
+import { strip as stripFromSrc } from '../src/strip.js'
 
 describe('main require', function () {
-  it('loads #html', function () {
+  it('exports html from src', function () {
     expect(html).to.equal(htmlFromSrc)
+  })
+
+  it('exports strip from src', function () {
+    expect(strip).to.equal(stripFromSrc)
   })
 })

--- a/test/strip.js
+++ b/test/strip.js
@@ -23,4 +23,8 @@ describe('#strip', function () {
   it('removes tags from multiline strings', function () {
     expect(strip('{red}line1\nline2\n{green}line3{/}')).to.eq('line1\nline2\nline3')
   })
+
+  it('leaves non-color tags untouched', function () {
+    expect(strip('{red}{foo}bar')).to.eq('{foo}bar')
+  })
 })

--- a/test/strip.js
+++ b/test/strip.js
@@ -1,0 +1,26 @@
+// @ts-check
+
+'use strict'
+
+import { expect } from '@dimensionalpocket/development'
+import { strip } from '../src/strip.js'
+
+describe('#strip', function () {
+  it('strips color tags from string', function () {
+    expect(strip('{red}value{/}')).to.eq('value')
+    expect(strip('{red}value1{green}value2{/}')).to.eq('value1value2')
+  })
+
+  it('respects spaces', function () {
+    expect(strip(' {red}value{/}')).to.eq(' value')
+    expect(strip('{red}value{/} ')).to.eq('value ')
+    expect(strip(' {red}value{/} ')).to.eq(' value ')
+    expect(strip('{red} value{/}')).to.eq(' value')
+    expect(strip('{red}value {/}')).to.eq('value ')
+    expect(strip('{red} value {/}')).to.eq(' value ')
+  })
+
+  it('removes tags from multiline strings', function () {
+    expect(strip('{red}line1\nline2\n{green}line3{/}')).to.eq('line1\nline2\nline3')
+  })
+})


### PR DESCRIPTION
`strip` method to remove all color tags from a string.